### PR TITLE
Harden SearXNG retry behavior and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ For detailed configuration options, see [SearXNG Documentation](https://docs.sea
 - `SEARXNG_USER_AGENT`: Custom User-Agent header for requests
   Default: `MCP-SearXNG/1.0`
 
+- `SEARXNG_MAX_ATTEMPTS`: Total number of attempts per instance (initial request + retries)
+  Default: `4` (1 initial attempt + 3 retries)
+
+- `SEARXNG_RETRY_BASE_DELAY_MS`: Base retry delay in milliseconds (exponential backoff)
+  Default: `300`
+
+- `SEARXNG_RETRY_JITTER_MS`: Random jitter added to each retry delay in milliseconds
+  Default: `100`
+
+- `SEARXNG_REQUEST_TIMEOUT_MS`: Per-attempt request timeout in milliseconds
+  Default: `10000`
+
 - `NODE_TLS_REJECT_UNAUTHORIZED`: Set to '0' to bypass SSL certificate verification (for development with self-signed certificates)
   Default: undefined (SSL verification enabled)
 
@@ -321,12 +333,21 @@ Example configuration with all options:
       "env": {
         "SEARXNG_INSTANCES": "http://localhost:8080,https://searx.example.com",
         "SEARXNG_USER_AGENT": "CustomBot/1.0",
+        "SEARXNG_MAX_ATTEMPTS": "4",
+        "SEARXNG_RETRY_BASE_DELAY_MS": "300",
+        "SEARXNG_RETRY_JITTER_MS": "100",
+        "SEARXNG_REQUEST_TIMEOUT_MS": "10000",
         "NODE_TLS_REJECT_UNAUTHORIZED": "0"
       }
     }
   }
 }
 ```
+
+When `NODE_ENV=test`, retry defaults are optimized for fast deterministic tests:
+- `SEARXNG_RETRY_BASE_DELAY_MS=1`
+- `SEARXNG_RETRY_JITTER_MS=0`
+- `SEARXNG_REQUEST_TIMEOUT_MS=1000`
 
 > ⚠️ Warning: Disabling SSL certificate verification is not recommended in production environments.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,43 @@
 export const USER_AGENT = process.env.SEARXNG_USER_AGENT || 'MCP-SearXNG/1.0';
 
+function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return fallback;
+  }
+
+  return Number(trimmed);
+}
+
+const isTestEnv = process.env.NODE_ENV === 'test';
+const defaultRetryBaseDelayMs = isTestEnv ? 1 : 300;
+const defaultRetryJitterMs = isTestEnv ? 0 : 100;
+const defaultRequestTimeoutMs = isTestEnv ? 1000 : 10000;
+
+export const SEARXNG_MAX_ATTEMPTS = Math.max(
+  1,
+  parseNonNegativeInt(process.env.SEARXNG_MAX_ATTEMPTS, 4)
+);
+export const SEARXNG_RETRY_BASE_DELAY_MS = parseNonNegativeInt(
+  process.env.SEARXNG_RETRY_BASE_DELAY_MS,
+  defaultRetryBaseDelayMs
+);
+export const SEARXNG_RETRY_JITTER_MS = parseNonNegativeInt(
+  process.env.SEARXNG_RETRY_JITTER_MS,
+  defaultRetryJitterMs
+);
+export const SEARXNG_REQUEST_TIMEOUT_MS = Math.max(
+  1,
+  parseNonNegativeInt(
+    process.env.SEARXNG_REQUEST_TIMEOUT_MS,
+    defaultRequestTimeoutMs
+  )
+);
+
 import { Agent as HttpsAgent } from 'node:https';
 import { Agent as HttpAgent } from 'node:http';
 

--- a/src/search-handler.ts
+++ b/src/search-handler.ts
@@ -1,5 +1,13 @@
 import fetch from 'node-fetch';
-import { USER_AGENT, httpsAgent, httpAgent } from './config.js';
+import {
+  USER_AGENT,
+  httpsAgent,
+  httpAgent,
+  SEARXNG_MAX_ATTEMPTS,
+  SEARXNG_RETRY_BASE_DELAY_MS,
+  SEARXNG_RETRY_JITTER_MS,
+  SEARXNG_REQUEST_TIMEOUT_MS
+} from './config.js';
 import type { StructuredSearchResponse } from './types.js';
 
 // Add debug logging function that can be enabled via environment variable
@@ -16,6 +24,129 @@ function logError(message: string, error?: unknown) {
   if (process.env.NODE_ENV !== 'test') {
     console.error(`Error: ${message}`, error ? `\n${error}` : '');
   }
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isRetriableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function parseRetryAfterMs(headerValue: string | null): number | undefined {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.floor(seconds * 1000));
+  }
+
+  const retryAfterDate = Date.parse(headerValue);
+  if (Number.isNaN(retryAfterDate)) {
+    return undefined;
+  }
+
+  return Math.max(0, retryAfterDate - Date.now());
+}
+
+function getRetryDelayMs(attempt: number): number {
+  const exponent = Math.max(attempt - 1, 0);
+  const backoffDelay = SEARXNG_RETRY_BASE_DELAY_MS * (2 ** exponent);
+  const jitter = SEARXNG_RETRY_JITTER_MS > 0
+    ? Math.floor(Math.random() * (SEARXNG_RETRY_JITTER_MS + 1))
+    : 0;
+
+  return backoffDelay + jitter;
+}
+
+async function executeSearchWithRetry(instance: string, searchParams: Record<string, string>): Promise<any> {
+  const searchUrl = new URL('/search', instance);
+  let lastError = 'Unknown error';
+  let attemptsUsed = 0;
+
+  for (let attempt = 1; attempt <= SEARXNG_MAX_ATTEMPTS; attempt += 1) {
+    attemptsUsed = attempt;
+    logDebug(`Attempt ${attempt}/${SEARXNG_MAX_ATTEMPTS} for instance: ${instance}`);
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort();
+      }, SEARXNG_REQUEST_TIMEOUT_MS);
+
+      let response;
+      try {
+        response = await fetch(searchUrl.toString(), {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT
+          },
+          agent: searchUrl.protocol === 'https:' ? httpsAgent : httpAgent as any,
+          body: new URLSearchParams(searchParams).toString(),
+          signal: controller.signal as any
+        });
+      } finally {
+        clearTimeout(timeoutId);
+      }
+
+      if (!response.ok) {
+        let errorText: string;
+        try {
+          errorText = await response.text();
+        } catch {
+          errorText = 'No response body available';
+        }
+
+        lastError = `${instance} returned HTTP ${response.status} ${response.statusText}. Response: ${errorText.substring(0, 200)}`;
+
+        if (isRetriableStatus(response.status) && attempt < SEARXNG_MAX_ATTEMPTS) {
+          const retryAfterMs = response.status === 429
+            ? parseRetryAfterMs(response.headers.get('retry-after'))
+            : undefined;
+          const retryDelayMs = retryAfterMs ?? getRetryDelayMs(attempt);
+          logDebug(`Retrying ${instance} after HTTP ${response.status}`, { attempt, retryDelayMs });
+          await delay(retryDelayMs);
+          continue;
+        }
+
+        break;
+      }
+
+      const data = await response.json();
+      if (!data.results?.length) {
+        lastError = `${instance} returned no results`;
+        break;
+      }
+
+      logDebug(`Search successful with ${instance}, found ${data.results.length} results`);
+      return data;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      lastError = `Failed to connect to ${instance}: ${errorMessage}`;
+
+      if (attempt < SEARXNG_MAX_ATTEMPTS) {
+        const retryDelayMs = getRetryDelayMs(attempt);
+        logDebug(`Retrying ${instance} after network error`, { attempt, retryDelayMs, errorMessage });
+        await delay(retryDelayMs);
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  throw new Error(`${instance} failed after ${attemptsUsed} attempt(s). Last error: ${lastError}`);
 }
 
 export class SearchHandler {
@@ -39,55 +170,24 @@ export class SearchHandler {
       safesearch: params.safesearch ?? 0,
       format: 'json'
     };
+
+    const serializedSearchParams = Object.entries(searchParams).reduce((acc, [key, value]) => {
+      acc[key] = String(value);
+      return acc;
+    }, {} as Record<string, string>);
     
     const errors: string[] = [];
     
     for (const instance of this.instances) {
       try {
-        const searchUrl = new URL('/search', instance);
-        logDebug(`Attempting search with instance: ${instance}`);
-        
-        const response = await fetch(searchUrl.toString(), {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'User-Agent': USER_AGENT
-          },
-          agent: searchUrl.protocol === 'https:' ? httpsAgent : httpAgent as any,
-          body: new URLSearchParams(Object.entries(searchParams).reduce((acc, [key, value]) => {
-            acc[key] = String(value);
-            return acc;
-          }, {} as Record<string, string>)).toString()
-        });
-
-        if (!response.ok) {
-          let errorText: string;
-          try {
-            errorText = await response.text();
-          } catch {
-            errorText = 'No response body available';
-          }
-          
-          const errorMsg = `${instance} returned HTTP ${response.status} ${response.statusText}. Response: ${errorText.substring(0, 200)}`;
-          logError(errorMsg);
-          errors.push(errorMsg);
-          continue;
-        }
-
-        const data = await response.json();
-        if (!data.results?.length) {
-          const errorMsg = `${instance} returned no results`;
-          logError(errorMsg);
-          errors.push(errorMsg);
-          continue;
-        }
-
-        logDebug(`Search successful with ${instance}, found ${data.results.length} results`);
+        const data = await executeSearchWithRetry(
+          instance,
+          serializedSearchParams
+        );
         return data;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        const errorMsg = `Failed to connect to ${instance}: ${errorMessage}`;
+        const errorMsg = errorMessage;
         logError(errorMsg, error);
         errors.push(errorMsg);
         continue;
@@ -120,51 +220,23 @@ export class ParallelSearchHandler extends SearchHandler {
       safesearch: params.safesearch ?? 0,
       format: 'json'
     };
+
+    const serializedSearchParams = Object.entries(searchParams).reduce((acc, [key, value]) => {
+      acc[key] = String(value);
+      return acc;
+    }, {} as Record<string, string>);
     
     const searchPromises = this.instances.map(async (instance) => {
       try {
-        const searchUrl = new URL('/search', instance);
-        logDebug(`Attempting search with instance: ${instance}`);
-        
-        const response = await fetch(searchUrl.toString(), {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'User-Agent': USER_AGENT
-          },
-          agent: searchUrl.protocol === 'https:' ? httpsAgent : httpAgent as any,
-          body: new URLSearchParams(Object.entries(searchParams).reduce((acc, [key, value]) => {
-            acc[key] = String(value);
-            return acc;
-          }, {} as Record<string, string>)).toString()
-        });
-
-         if (!response.ok) {
-           let errorText: string;
-           try {
-             errorText = await response.text();
-           } catch {
-             errorText = 'No response body available';
-           }
-           
-           const errorMsg = `${instance} returned HTTP ${response.status} ${response.statusText}. Response: ${errorText.substring(0, 200)}`;
-           throw new Error(errorMsg);
-         }
-
-         const data = await response.json();
-         if (!data.results?.length) {
-           const errorMsg = `${instance} returned no results`;
-           throw new Error(errorMsg);
-         }
-
-        logDebug(`Search successful with ${instance}, found ${data.results.length} results`);
+        const data = await executeSearchWithRetry(
+          instance,
+          serializedSearchParams
+        );
         return data;
-       } catch (error) {
-         const errorMessage = error instanceof Error ? error.message : String(error);
-         const errorMsg = `Failed to connect to ${instance}: ${errorMessage}`;
-         throw new Error(errorMsg);
-       }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(errorMessage);
+      }
     });
 
     const results = await Promise.allSettled(searchPromises);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -280,12 +280,13 @@ describe('SearXNG MCP Server', () => {
 
     it('should try multiple instances on failure', async () => {
       // First instance returns 500
-      nock('https://instance1')
+      const instance1Scope = nock('https://instance1')
         .post('/search')
+        .times(4)
         .reply(500);
 
       // Second instance returns successful results
-      nock('https://instance2')
+      const instance2Scope = nock('https://instance2')
         .post('/search')
         .reply(200, {
           results: [{
@@ -302,6 +303,8 @@ describe('SearXNG MCP Server', () => {
 
       expect(result.results).toBeDefined();
       expect(result.results.length).toBe(1);
+      expect(instance1Scope.isDone()).toBe(true);
+      expect(instance2Scope.isDone()).toBe(true);
     });
 
     it('should handle no results', async () => {
@@ -317,6 +320,229 @@ describe('SearXNG MCP Server', () => {
       await expect(searchWithFallback({
         query: 'test'
       })).rejects.toThrow('All SearXNG instances failed');
+    });
+
+    it('should retry transient 500 errors and eventually succeed', async () => {
+      SEARXNG_INSTANCES.length = 0;
+      SEARXNG_INSTANCES.push('https://instance1');
+
+      nock('https://instance1')
+        .post('/search')
+        .reply(500, { error: 'temporary failure' })
+        .post('/search')
+        .reply(500, { error: 'temporary failure' })
+        .post('/search')
+        .reply(500, { error: 'temporary failure' })
+        .post('/search')
+        .reply(200, {
+          results: [{
+            title: 'Recovered Result',
+            url: 'https://test.com/recovered',
+            content: 'Recovered after retries',
+            engine: 'test-engine'
+          }]
+        });
+
+      const result = await searchWithFallback({ query: 'retry test' });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].title).toBe('Recovered Result');
+    });
+
+    it('should stop after 4 total attempts on persistent 500 errors', async () => {
+      SEARXNG_INSTANCES.length = 0;
+      SEARXNG_INSTANCES.push('https://instance1');
+
+      nock('https://instance1')
+        .post('/search')
+        .times(4)
+        .reply(500, { error: 'still failing' });
+
+      await expect(searchWithFallback({ query: 'always failing test' })).rejects.toThrow('failed after 4 attempt(s)');
+    });
+
+    it('should not retry non-transient 400 errors', async () => {
+      SEARXNG_INSTANCES.length = 0;
+      SEARXNG_INSTANCES.push('https://instance1');
+
+      nock('https://instance1')
+        .post('/search')
+        .reply(400, { error: 'bad request' });
+
+      await expect(searchWithFallback({ query: 'bad request test' })).rejects.toThrow('failed after 1 attempt(s)');
+    });
+
+    it('should succeed in parallel mode when one instance recovers after retries', async () => {
+      nock('https://instance1')
+        .post('/search')
+        .reply(500, { error: 'temporary failure' })
+        .post('/search')
+        .reply(500, { error: 'temporary failure' })
+        .post('/search')
+        .reply(200, {
+          results: [{
+            title: 'Instance 1 Result',
+            url: 'https://instance1-result.com',
+            content: 'Recovered in parallel mode',
+            engine: 'instance1'
+          }]
+        });
+
+      nock('https://instance2')
+        .post('/search')
+        .times(4)
+        .reply(500, { error: 'always failing' });
+
+      const result = await searchWithFallback({ query: 'parallel retry test' });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].title).toBe('Instance 1 Result');
+    });
+
+    it('should retry on HTTP 408 and eventually succeed', async () => {
+      SEARXNG_INSTANCES.length = 0;
+      SEARXNG_INSTANCES.push('https://instance1');
+
+      nock('https://instance1')
+        .post('/search')
+        .reply(408, { error: 'request timeout' })
+        .post('/search')
+        .reply(408, { error: 'request timeout' })
+        .post('/search')
+        .reply(200, {
+          results: [{
+            title: 'Recovered from 408',
+            url: 'https://test.com/408-recovered',
+            content: 'Eventually successful',
+            engine: 'test-engine'
+          }]
+        });
+
+      const result = await searchWithFallback({ query: 'retry 408 test' });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].title).toBe('Recovered from 408');
+    });
+
+    it('should honor Retry-After on HTTP 429 responses', async () => {
+      const originalAttempts = process.env.SEARXNG_MAX_ATTEMPTS;
+      const originalBaseDelay = process.env.SEARXNG_RETRY_BASE_DELAY_MS;
+      const originalJitter = process.env.SEARXNG_RETRY_JITTER_MS;
+      const originalTimeout = process.env.SEARXNG_REQUEST_TIMEOUT_MS;
+
+      process.env.SEARXNG_MAX_ATTEMPTS = '4';
+      process.env.SEARXNG_RETRY_BASE_DELAY_MS = '1';
+      process.env.SEARXNG_RETRY_JITTER_MS = '0';
+      process.env.SEARXNG_REQUEST_TIMEOUT_MS = '1000';
+
+      try {
+        await jest.isolateModulesAsync(async () => {
+          const indexModule = await import('../src/index');
+          const isolatedInstances = indexModule.SEARXNG_INSTANCES;
+          isolatedInstances.length = 0;
+          isolatedInstances.push('https://instance-retry-after');
+
+          nock('https://instance-retry-after')
+            .post('/search')
+            .reply(429, { error: 'rate limited' }, { 'Retry-After': '1' })
+            .post('/search')
+            .reply(200, {
+              results: [{
+                title: 'Recovered after Retry-After',
+                url: 'https://test.com/retry-after',
+                content: 'Rate limit recovered',
+                engine: 'test-engine'
+              }]
+            });
+
+          const startTime = Date.now();
+          const result = await indexModule.searchWithFallback({ query: 'retry-after test' });
+          const elapsedMs = Date.now() - startTime;
+
+          expect(result.results).toHaveLength(1);
+          expect(elapsedMs).toBeGreaterThanOrEqual(900);
+        });
+      } finally {
+        if (originalAttempts === undefined) {
+          delete process.env.SEARXNG_MAX_ATTEMPTS;
+        } else {
+          process.env.SEARXNG_MAX_ATTEMPTS = originalAttempts;
+        }
+
+        if (originalBaseDelay === undefined) {
+          delete process.env.SEARXNG_RETRY_BASE_DELAY_MS;
+        } else {
+          process.env.SEARXNG_RETRY_BASE_DELAY_MS = originalBaseDelay;
+        }
+
+        if (originalJitter === undefined) {
+          delete process.env.SEARXNG_RETRY_JITTER_MS;
+        } else {
+          process.env.SEARXNG_RETRY_JITTER_MS = originalJitter;
+        }
+
+        if (originalTimeout === undefined) {
+          delete process.env.SEARXNG_REQUEST_TIMEOUT_MS;
+        } else {
+          process.env.SEARXNG_REQUEST_TIMEOUT_MS = originalTimeout;
+        }
+      }
+    });
+
+    it('should apply exponential backoff delays between retries', async () => {
+      const originalAttempts = process.env.SEARXNG_MAX_ATTEMPTS;
+      const originalBaseDelay = process.env.SEARXNG_RETRY_BASE_DELAY_MS;
+      const originalJitter = process.env.SEARXNG_RETRY_JITTER_MS;
+      const originalTimeout = process.env.SEARXNG_REQUEST_TIMEOUT_MS;
+
+      process.env.SEARXNG_MAX_ATTEMPTS = '4';
+      process.env.SEARXNG_RETRY_BASE_DELAY_MS = '20';
+      process.env.SEARXNG_RETRY_JITTER_MS = '0';
+      process.env.SEARXNG_REQUEST_TIMEOUT_MS = '1000';
+
+      try {
+        await jest.isolateModulesAsync(async () => {
+          const indexModule = await import('../src/index');
+          const isolatedInstances = indexModule.SEARXNG_INSTANCES;
+          isolatedInstances.length = 0;
+          isolatedInstances.push('https://instance-backoff');
+
+          nock('https://instance-backoff')
+            .post('/search')
+            .times(4)
+            .reply(500, { error: 'always failing' });
+
+          const startTime = Date.now();
+          await expect(indexModule.searchWithFallback({ query: 'backoff delay test' })).rejects.toThrow('failed after 4 attempt(s)');
+          const elapsedMs = Date.now() - startTime;
+
+          expect(elapsedMs).toBeGreaterThanOrEqual(120);
+        });
+      } finally {
+        if (originalAttempts === undefined) {
+          delete process.env.SEARXNG_MAX_ATTEMPTS;
+        } else {
+          process.env.SEARXNG_MAX_ATTEMPTS = originalAttempts;
+        }
+
+        if (originalBaseDelay === undefined) {
+          delete process.env.SEARXNG_RETRY_BASE_DELAY_MS;
+        } else {
+          process.env.SEARXNG_RETRY_BASE_DELAY_MS = originalBaseDelay;
+        }
+
+        if (originalJitter === undefined) {
+          delete process.env.SEARXNG_RETRY_JITTER_MS;
+        } else {
+          process.env.SEARXNG_RETRY_JITTER_MS = originalJitter;
+        }
+
+        if (originalTimeout === undefined) {
+          delete process.env.SEARXNG_REQUEST_TIMEOUT_MS;
+        } else {
+          process.env.SEARXNG_REQUEST_TIMEOUT_MS = originalTimeout;
+        }
+      }
     });
   });
 }); 


### PR DESCRIPTION
## Summary
- add resilient retry behavior for SearXNG requests with 4 total attempts by default (initial request plus 3 retries)
- handle transient conditions more safely by retrying on 408/429/5xx, honoring `Retry-After` for 429, and enforcing per-attempt request timeouts
- tighten retry-related env parsing/config defaults and expand README docs plus test coverage for retries, backoff timing, and fallback/parallel behavior

## Validation
- npm test
- npm run build